### PR TITLE
Make ws connection work with python3

### DIFF
--- a/_posts/2015-09-11-playing-with-websockets.markdown
+++ b/_posts/2015-09-11-playing-with-websockets.markdown
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     factory.protocol = SomeServerProtocol
     resource = WebSocketResource(factory)
     # websockets resource on "/ws" path
-    root.putChild(u"ws", resource)
+    root.putChild(b"ws", resource)
 
     site = Site(root)
     reactor.listenTCP(8080, site)


### PR DESCRIPTION
Thanks for the great example.

With python3, for some reason the "path" argument to putChild() needs to be of type bytes, otherwise the browser couldn't make the ws connection.
( https://github.com/twisted/twisted/blob/7f63174798c4b0b1be879b2dca014f4054a58ad1/src/twisted/web/resource.py#L70 )
This change still worked when I tested it with python 2.7.6

Also, the pastebin version of the code is linked in the post and would need a similar change.
